### PR TITLE
Updates the namespace for packages

### DIFF
--- a/features/org.dataflowanalysis.product.feature/feature.xml
+++ b/features/org.dataflowanalysis.product.feature/feature.xml
@@ -156,8 +156,9 @@
       <import plugin="org.palladiosimulator.architecturaltemplates.ui" version="1.0.1" match="greaterOrEqual"/>
       <import plugin="org.palladiosimulator.pcm.stoex.ui" version="5.0.0" match="greaterOrEqual"/>
 	  <import feature="org.palladiosimulator.editors.sirius.feature" version="5.1.0" match="compatible"/>
-
-	  <import plugin="org.palladiosimulator.dataflow.confidentiality.analysis" version="1.0.0" match="compatible"/>
+	  <!--Data Flow Analysis-->
+	  <import feature="org.dataflowanalysis.analysis.feature" version="1.0.0" match="compatible"/>
+      <!--PCM Data Flow Analysis Extension-->
       <import feature="org.palladiosimulator.dataflow.confidentiality.pcm.feature" version="5.1.0" match="compatible"/>
    </requires>
 </feature>

--- a/features/org.dataflowanalysis.product.feature/feature.xml
+++ b/features/org.dataflowanalysis.product.feature/feature.xml
@@ -159,6 +159,6 @@
 	  <!--Data Flow Analysis-->
 	  <import feature="org.dataflowanalysis.analysis.feature" version="1.0.0" match="compatible"/>
       <!--PCM Data Flow Analysis Extension-->
-      <import feature="org.palladiosimulator.dataflow.confidentiality.pcm.feature" version="5.1.0" match="compatible"/>
+      <import feature="org.dataflowanalysis.pcm.extension.feature" version="5.1.0" match="compatible"/>
    </requires>
 </feature>

--- a/releng/org.dataflowanalysis.product.targetplatform/org.dataflowanalysis.product.targetplatform.target
+++ b/releng/org.dataflowanalysis.product.targetplatform/org.dataflowanalysis.product.targetplatform.target
@@ -68,11 +68,11 @@
     </location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<unit id="org.palladiosimulator.dataflow.confidentiality.pcm.feature.feature.group" version="0.0.0"/>
+			<unit id="org.dataflowanalysis.pcm.extension.feature.feature.group" version="0.0.0"/>
 			<repository location="https://dataflowanalysis.github.io/updatesite/nightly/pcm-dataflowanalysis-extension/"/>
 	</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<unit id="org.palladiosimulator.dataflow.confidentiality.analysis.feature.feature.group" version="0.0.0"/>
+			<unit id="org.dataflowanalysis.analysis.feature.feature.group" version="0.0.0"/>
 			<repository location="https://dataflowanalysis.github.io/updatesite/nightly/dataflowanalysis/"/>
 	</location>
 	<location  includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
This PR updates the namespace for the following projects:
- The Dataflow Analysis (now: `org.dataflowanalysis.analysis`)
- The PCM Dataflow Metamodel (now: `org.dataflowanalysis.pcm.extension`)

The corresponding PRs in these Repositories should also be merged first