### PR TITLE
Add CDO Debug Utils

### DIFF
--- a/features/org.dataflowanalysis.product.feature/feature.xml
+++ b/features/org.dataflowanalysis.product.feature/feature.xml
@@ -147,6 +147,7 @@
       <import plugin="tools.mdsd.library.emfeditutils" version="0.1.0" match="greaterOrEqual"/>
       <import plugin="tools.mdsd.ecoreworkflow.mwe2lib"/>
       <import plugin="tools.mdsd.junit5utils"/>
+      <import feature="tools.mdsd.cdo.debug.feature" version="0.1.0" match="compatible"/>
       <import plugin="org.palladiosimulator.pcm" version="5.2.0" match="greaterOrEqual"/>
       <import plugin="org.palladiosimulator.pcm.editor" version="5.2.0" match="greaterOrEqual"/>
       <import plugin="org.palladiosimulator.pcm.edit" version="5.2.0" match="greaterOrEqual"/>

--- a/releng/org.dataflowanalysis.product.targetplatform/org.dataflowanalysis.product.targetplatform.target
+++ b/releng/org.dataflowanalysis.product.targetplatform/org.dataflowanalysis.product.targetplatform.target
@@ -63,6 +63,10 @@
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 	<repository location="https://updatesite.mdsd.tools/ecore-workflow/nightly/"/>
 	<unit id="tools.mdsd.ecoreworkflow.mwe2lib.feature.feature.group" version="0.0.0"/>
+      </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<repository location="https://updatesite.mdsd.tools/eclipseaddon-cdodebugutils/nightly/"/>
+	<unit id="tools.mdsd.cdo.debug.feature.feature.group" version="0.0.0"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 	<repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/releases/0.3.0/"/>


### PR DESCRIPTION
This PR adds the CDO Debug utils from MDSD Tools to allow better debugging of ECore elements.
If possible, this should also be already included in release v2.0.0