### PR TITLE
Fix missing permissions on workflow run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,6 +28,8 @@ jobs:
 
     - name: Add artifacts to release
       uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         generate_release_notes: true
         repository: DataFlowAnalysis/product


### PR DESCRIPTION
Looking at the workflow run [here](https://github.com/DataFlowAnalysis/product/actions/runs/9345978731) it seems the workflow does not have sufficient permissions to release the artifacts. It may be enough to publish these changes, but it also may require workflows writing to repositories, which can be configured in the `Workflow settings`