### PR TITLE
Add scripts and pipeline for eclipse-less jar build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,33 @@ name: Build Updatesite
 on: workflow_dispatch
 
 jobs:
-  DataFlowAnalysis-Product:
+  build-product:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+      
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 17
+    - name: Setup Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.6      
+    - name: Verify with Maven
+      shell: bash
+      run: mvn clean verify
+
+    - name: Create jar-only build
+      shell: bash 
+      run: scripts/create-jar-only-build.sh
+  deploy-product:
     uses: PalladioSimulator/Palladio-Build-ActionsPipeline/.github/workflows/build.yml@master
+    needs: build-product
     with:
       use-display-output: true
       no-caching: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,22 +23,31 @@ jobs:
     - name: Verify with Maven
       shell: bash
       run: mvn clean verify
-
     - name: Create jar-only build
       shell: bash 
       run: scripts/create-jar-only-build.sh
-  deploy-product:
-    uses: PalladioSimulator/Palladio-Build-ActionsPipeline/.github/workflows/build.yml@master
-    needs: build-product
-    with:
-      use-display-output: true
-      no-caching: true
-      java-version: 17
-      runner-label: ubuntu-latest
-      deploy-updatesite: 'products/org.dataflowanalysis.product/target/deploy'
-    secrets:
-      SERVER_SSH_KEY: ${{ secrets.PALLADIO_UPDATESITE_SSH }}
-      REMOTE_HOST: ${{ secrets.PALLADIO_REMOTE_HOST }}
-      REMOTE_PORT: ${{ secrets.PALLADIO_REMOTE_PORT }}
-      REMOTE_USER: ${{ secrets.PALLADIO_REMOTE_USER }}
-      REMOTE_TARGET: ${{ secrets.PALLADIO_REMOTE_TARGET }}
+    - name: Create folder name
+      shell: bash
+      run: echo "DEPLOY_FOLDER=$( echo ${{ github.repository }} | cut -d'/' -f2 | sed -e 's/\(.*\)/\L\1/' )" >> $GITHUB_ENV
+    - name: Create project deployment path
+      shell: bash
+      run: echo "PROJECT_DEPLOY_PATH=$( echo '${{ secrets.PALLADIO_REMOTE_TARGET}}/${{ env.DEPLOY_FOLDER }}' )" >> $GITHUB_ENV
+    - name: Create Deployment Path
+      shell: bash
+      run: |
+        if ${{ github.ref_name == 'master' }} || ${{ github.ref_name == 'main' }}
+        then
+            echo "REMOTE_PATH=$( echo '${{ env.PROJECT_DEPLOY_PATH }}/nightly' )" >> $GITHUB_ENV
+        else
+            echo "REMOTE_PATH=$( echo '${{ env.PROJECT_DEPLOY_PATH }}/branches/${{ github.ref_name }}' )" >> $GITHUB_ENV
+        fi
+    - name: Deploy to Updatesite
+      uses: PalladioSimulator/Palladio-Build-ActionsPipeline-Deployment@v3
+      with:
+        remote-user: ${{ secrets.PALLADIO_REMOTE_USER }}
+        remote-host: ${{ secrets.PALLADIO_REMOTE_HOST }}
+        remote-port: ${{ secrets.PALLADIO_REMOTE_PORT }}
+        server-ssh-key: ${{ secrets.PALLADIO_UPDATESITE_SSH }}
+        local-source: './products/org.dataflowanalysis.product/target/deploy/*'
+        remote-target: ${{ env.REMOTE_PATH }}
+        link-path: ${{ env.PROJECT_DEPLOY_PATH }} 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,13 @@ jobs:
     - name: Create jar-only build
       shell: bash 
       run: scripts/create-jar-only-build.sh
-    - name: Create folder name
+    - name: Determine remote folder name
       shell: bash
       run: echo "DEPLOY_FOLDER=$( echo ${{ github.repository }} | cut -d'/' -f2 | sed -e 's/\(.*\)/\L\1/' )" >> $GITHUB_ENV
-    - name: Create project deployment path
+    - name: Determine remote folder location
       shell: bash
       run: echo "PROJECT_DEPLOY_PATH=$( echo '${{ secrets.PALLADIO_REMOTE_TARGET}}/${{ env.DEPLOY_FOLDER }}' )" >> $GITHUB_ENV
-    - name: Create Deployment Path
+    - name: Determine remote folder suffix
       shell: bash
       run: |
         if ${{ github.ref_name == 'master' }} || ${{ github.ref_name == 'main' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,22 @@ jobs:
           products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis.win32.win32.x86_64.zip
           products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis.macosx.cocoa.aarch64.tar.gz
           products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis.jars.tar.gz
+    - name: Determine name of deployment folder
+      shell: bash
+      run: echo "DEPLOY_FOLDER=$( echo ${{ github.repository }} | cut -d'/' -f2 | sed -e 's/\(.*\)/\L\1/' )" >> $GITHUB_ENV
+    - name: Determine deployment path
+      shell: bash
+      run: echo "PROJECT_DEPLOY_PATH=$( echo '${{ secrets.PALLADIO_REMOTE_TARGET}}/${{ env.DEPLOY_FOLDER }}' )" >> $GITHUB_ENV
+    - name: Determine deployment folder suffix
+      shell: bash
+      run: echo "REMOTE_PATH=$( echo '${{ env.PROJECT_DEPLOY_PATH }}/releases/${{ github.event.release.tag_name }}' )" >> $GITHUB_ENV 
+    - name: Deploy to Updatesite
+      uses: PalladioSimulator/Palladio-Build-ActionsPipeline-Deployment@v3
+      with:
+        remote-user: ${{ secrets.PALLADIO_REMOTE_USER }}
+        remote-host: ${{ secrets.PALLADIO_REMOTE_HOST }}
+        remote-port: ${{ secrets.PALLADIO_REMOTE_PORT }}
+        server-ssh-key: ${{ secrets.PALLADIO_UPDATESITE_SSH }}
+        local-source: './products/org.dataflowanalysis.product/target/deploy/*'
+        remote-target: ${{ env.REMOTE_PATH }}
+        link-path: ${{ env.PROJECT_DEPLOY_PATH }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
       shell: bash
       run: mvn clean verify
 
+    - name: Create jar-only build
+      shell: bash 
+      run: scripts/create-jar-only-build.sh
     - name: Add artifacts to release
       uses: softprops/action-gh-release@v2
       env:
@@ -41,3 +44,4 @@ jobs:
           products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis.macosx.cocoa.x86_64.tar.gz
           products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis.win32.win32.x86_64.zip
           products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis.macosx.cocoa.aarch64.tar.gz
+          products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis.jars.tar.gz

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.5</version>
+		<version>4.0.9</version>
 	</extension>
 </extensions>

--- a/scripts/create-jar-only-build.sh
+++ b/scripts/create-jar-only-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+# Unpack linux build to get jars
+echo "Unpacking product"
+mkdir -p products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis
+tar -xf products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis.linux.gtk.x86_64.tar.gz -C products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis
+echo "Finished unpacking product"
+
+# Rename jars to remove date of build (only name and version should be in the name)
+echo "Renaming jars..."
+for file in products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis/plugins/*.jar; do
+  if [ -e "$file" ]; then
+    newname=$(echo "$file" | sed -r 's|(.*)\_([0-9]+\.[0-9]+\.[0-9]+).*$|\1\2.jar|')
+    mv "$file" "$newname"
+  fi
+done
+echo "Finished renaming jars!"
+
+# Pack the jars into an archive
+echo "Repacking archive"
+tar -cf products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis.jars.tar.gz products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis/plugins
+echo "Repacked archive"
+
+# Cleanup files
+rm -rf products/org.dataflowanalysis.product/target/deploy/DataFlowAnalysis


### PR DESCRIPTION
This PR adds a script in `scripts/create-jar-only-build.sh` that creates a new archive that only contains the eclipse plugins.
It strips them from their build time endings, so they can be used more easily in external tools